### PR TITLE
feat: add dynamic guts valuation

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
                         <svg class="collapse-icon h-6 w-6 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
                     </div>
                     <div id="target-stats-content" class="collapsible-content">
-                         <div class="mt-3">
+                        <div class="mt-3">
                             <label for="target-preset-select" class="block text-sm font-medium text-gray-700">Select Preset</label>
                             <select id="target-preset-select" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2 text-sm">
                                 <option value="sprint">Sprint</option>
@@ -146,7 +146,21 @@
                                 <option value="custom">Custom</option>
                             </select>
                         </div>
-                         <div id="target-stats-inputs" class="space-y-2 mt-3"></div>
+                        <div class="flex items-center space-x-2 mt-3">
+                            <input type="checkbox" id="dynamic-guts-toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                            <label for="dynamic-guts-toggle" class="text-sm font-medium text-gray-700">Dynamic Guts Valuation</label>
+                        </div>
+                        <div class="mt-3">
+                            <label for="target-distance-select" class="block text-sm font-medium text-gray-700">Target Distance</label>
+                            <select id="target-distance-select" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2 text-sm" disabled>
+                                <option value="1400">1400m</option>
+                                <option value="1800">1800m</option>
+                                <option value="2400" selected>2400m</option>
+                                <option value="3000">3000m</option>
+                                <option value="3600">3600m</option>
+                            </select>
+                        </div>
+                        <div id="target-stats-inputs" class="space-y-2 mt-3"></div>
                     </div>
                 </div>
             </div>
@@ -305,6 +319,8 @@
             long:   { speed: 1200, stamina: 1200, power: 1200, guts: 400, wit: 400 }
         };
 
+        const PRESET_DISTANCES = { sprint: 1400, mile: 1800, medium: 2400, long: 3000 };
+
         const TRAINING_DATA = {
             Speed:   { base_cost: 21, levels: [{ speed: 10, power: 5 }, { speed: 11, power: 5 }, { speed: 12, power: 5 }, { speed: 13, power: 6 }, { speed: 14, power: 7 }] },
             Stamina: { base_cost: 19, levels: [{ stamina: 9, guts: 4 }, { stamina: 10, guts: 4 }, { stamina: 11, guts: 4 }, { stamina: 12, guts: 5 }, { stamina: 13, guts: 6 }] },
@@ -369,6 +385,8 @@
         const goalSeekList = document.getElementById('goal-seek-results-list');
         const goalSeekCloseButton = document.getElementById('goal-seek-modal-close-button');
         const targetPresetSelect = document.getElementById('target-preset-select');
+        const dynamicGutsToggle = document.getElementById('dynamic-guts-toggle');
+        const targetDistanceSelect = document.getElementById('target-distance-select');
         const settingsButton = document.getElementById('settings-button');
         const settingsModal = document.getElementById('settings-modal');
         const settingsModalCloseButton = document.getElementById('settings-modal-close-button');
@@ -407,6 +425,11 @@
                         if (select) select.value = targets.priorities[stat];
                     }
                 });
+                dynamicGutsToggle.checked = targets.dynamicGuts || false;
+                if (targets.distance) {
+                    targetDistanceSelect.value = targets.distance;
+                }
+                updateDynamicGutsUI();
                 // Check if the loaded values match a preset
                 let matchedPreset = 'custom';
                 for (const presetName in TARGET_PRESETS) {
@@ -423,6 +446,7 @@
                 // No saved data, apply default
                 applyTargetPreset('medium');
                 targetPresetSelect.value = 'medium';
+                updateDynamicGutsUI();
             }
         }
 
@@ -612,7 +636,27 @@
                 saveTargetsToLocalStorage();
             });
         }
-        
+
+        function updateDynamicGutsUI() {
+            targetDistanceSelect.disabled = !dynamicGutsToggle.checked;
+            const gutPriority = document.getElementById('priority-guts');
+            if (gutPriority) {
+                gutPriority.disabled = dynamicGutsToggle.checked;
+                if (dynamicGutsToggle.checked) gutPriority.value = 0;
+            }
+        }
+
+        dynamicGutsToggle.addEventListener('change', () => {
+            targetPresetSelect.value = 'custom';
+            updateDynamicGutsUI();
+            saveTargetsToLocalStorage();
+        });
+
+        targetDistanceSelect.addEventListener('change', () => {
+            targetPresetSelect.value = 'custom';
+            saveTargetsToLocalStorage();
+        });
+
         function setupStatsUI() {
             const colors = { speed: 'blue', stamina: 'red', power: 'yellow', guts: 'purple', wit: 'indigo' };
             statsContainer.innerHTML = STAT_MAP.map(stat => `
@@ -1200,6 +1244,20 @@
             return finalGains;
         }
 
+        function baseGuts(distance) {
+            if (distance <= 1600) return 210;
+            if (distance <= 2000) return 260;
+            if (distance <= 2600) return 320;
+            if (distance <= 3200) return 380;
+            return 440;
+        }
+
+        function gutsToStamina(guts, distance) {
+            const G0 = baseGuts(distance);
+            const A = (0.000858 * distance + 12.2156) * (distance / 3);
+            return A * (1 / Math.sqrt(G0) - 1 / Math.sqrt(Math.max(guts, 1)));
+        }
+
         function runAITurn(gs, targetStats, bondWeights, delayForRainbows, isSilent = false) {
             if (gs.day === 1 && !gs.initialStatsApplied) {
                 applyInitialCardStats(gs);
@@ -1273,17 +1331,42 @@
                     const presentCards = gs.supportCards.filter(c => c && c.location === t.type);
                     const potentialGains = calculatePotentialGains(gs, t.type, presentCards);
                     let score = 0;
-                    for (const stat in potentialGains) {
-                        const currentStatValue = gs.stats[stat];
-                        const targetStatValue = targetStats.values[stat];
-                        const priority = targetStats.priorities[stat];
-                        const gain = potentialGains[stat];
-                        
-                        if (currentStatValue >= 1200) continue;
-                        const usefulGain = Math.min(gain, 1200 - currentStatValue);
+                    if (targetStats.dynamicGuts) {
+                        ['speed', 'power', 'wit'].forEach(stat => {
+                            const gain = potentialGains[stat] || 0;
+                            const currentStatValue = gs.stats[stat];
+                            const targetStatValue = targetStats.values[stat];
+                            const priority = targetStats.priorities[stat];
+                            if (currentStatValue >= 1200) return;
+                            const usefulGain = Math.min(gain, 1200 - currentStatValue);
+                            if (currentStatValue < targetStatValue) {
+                                score += usefulGain * priority;
+                            }
+                        });
+                        const distance = targetStats.distance;
+                        const currentEff = gs.stats.stamina + gutsToStamina(gs.stats.guts, distance);
+                        const targetEff = targetStats.values.stamina + gutsToStamina(targetStats.values.guts, distance);
+                        if (currentEff < targetEff) {
+                            const staminaGain = potentialGains.stamina || 0;
+                            const gutsGain = potentialGains.guts || 0;
+                            const newEff = (gs.stats.stamina + staminaGain) + gutsToStamina(gs.stats.guts + gutsGain, distance);
+                            let gainEff = newEff - currentEff;
+                            gainEff = Math.min(gainEff, 1200 - currentEff);
+                            score += gainEff * targetStats.priorities.stamina;
+                        }
+                    } else {
+                        for (const stat in potentialGains) {
+                            const currentStatValue = gs.stats[stat];
+                            const targetStatValue = targetStats.values[stat];
+                            const priority = targetStats.priorities[stat];
+                            const gain = potentialGains[stat];
 
-                        if (currentStatValue < targetStatValue) {
-                            score += usefulGain * priority;
+                            if (currentStatValue >= 1200) continue;
+                            const usefulGain = Math.min(gain, 1200 - currentStatValue);
+
+                            if (currentStatValue < targetStatValue) {
+                                score += usefulGain * priority;
+                            }
                         }
                     }
                     return { ...t, score };
@@ -1304,8 +1387,8 @@
         }
 
         function getTargetStatsFromUI() {
-            const targets = { values: {}, priorities: {} };
-            STAT_MAP.forEach(stat => { 
+            const targets = { values: {}, priorities: {}, dynamicGuts: dynamicGutsToggle.checked, distance: parseInt(targetDistanceSelect.value) || 0 };
+            STAT_MAP.forEach(stat => {
                 targets.values[stat] = parseInt(document.getElementById(`target-${stat}`).value) || 0;
                 targets.priorities[stat] = parseFloat(document.getElementById(`priority-${stat}`).value) || 1;
             });
@@ -1380,10 +1463,22 @@
             localGS.stats.total = STAT_MAP.reduce((sum, stat) => sum + localGS.stats[stat], 0);
             
             localGS.stats.metTargets = {};
-            STAT_MAP.forEach(stat => {
-                localGS.stats.metTargets[stat] = localGS.stats[stat] >= targetStats.values[stat];
-            });
-            
+            if (targetStats.dynamicGuts) {
+                const distance = targetStats.distance;
+                const currentEff = localGS.stats.stamina + gutsToStamina(localGS.stats.guts, distance);
+                const targetEff = targetStats.values.stamina + gutsToStamina(targetStats.values.guts, distance);
+                localGS.stats.metTargets.stamina = currentEff >= targetEff;
+                ['speed', 'power', 'guts', 'wit'].forEach(stat => {
+                    if (stat !== 'stamina') {
+                        localGS.stats.metTargets[stat] = localGS.stats[stat] >= targetStats.values[stat];
+                    }
+                });
+            } else {
+                STAT_MAP.forEach(stat => {
+                    localGS.stats.metTargets[stat] = localGS.stats[stat] >= targetStats.values[stat];
+                });
+            }
+
             return localGS.stats;
         }
 
@@ -1506,12 +1601,26 @@
             let totalWeightedSum = 0;
             for (let i = 0; i < numRuns; i++) {
                 const result = runSilentSimulation(targetStats, bondWeights, currentSettings.delayForRainbows);
-                const weightedTotal = STAT_MAP.reduce((sum, stat) => {
-                    const statValue = result[stat];
-                    const targetValue = targetStats.values[stat];
-                    const priority = targetStats.priorities[stat];
-                    return sum + Math.min(statValue, targetValue) * priority;
-                }, 0);
+                let weightedTotal = 0;
+                if (targetStats.dynamicGuts) {
+                    const distance = targetStats.distance;
+                    const effStat = result.stamina + gutsToStamina(result.guts, distance);
+                    const effTarget = targetStats.values.stamina + gutsToStamina(targetStats.values.guts, distance);
+                    weightedTotal += Math.min(effStat, effTarget) * targetStats.priorities.stamina;
+                    ['speed', 'power', 'wit'].forEach(stat => {
+                        const statValue = result[stat];
+                        const targetValue = targetStats.values[stat];
+                        const priority = targetStats.priorities[stat];
+                        weightedTotal += Math.min(statValue, targetValue) * priority;
+                    });
+                } else {
+                    weightedTotal = STAT_MAP.reduce((sum, stat) => {
+                        const statValue = result[stat];
+                        const targetValue = targetStats.values[stat];
+                        const priority = targetStats.priorities[stat];
+                        return sum + Math.min(statValue, targetValue) * priority;
+                    }, 0);
+                }
                 totalWeightedSum += weightedTotal;
             }
             return totalWeightedSum / numRuns;
@@ -1611,6 +1720,11 @@
                     input.value = preset[stat];
                 }
             }
+            const dist = PRESET_DISTANCES[presetName];
+            if (dist) {
+                targetDistanceSelect.value = dist;
+            }
+            updateDynamicGutsUI();
             saveTargetsToLocalStorage(); // Save after applying
         }
         


### PR DESCRIPTION
## Summary
- add dynamic guts valuation toggle and distance selection
- convert guts to stamina equivalent using race distance
- adjust training, simulation, and goal seek scoring for stamina equivalence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0d54a3a4883228e4a0d443dae88d8