### PR TITLE
Fix event log ordering and cutoff

### DIFF
--- a/index.html
+++ b/index.html
@@ -1160,8 +1160,7 @@
 
         function logEvent(message, type = 'system') {
             if (gameState) {
-                gameState.log.unshift({ day: gameState.day, message, type });
-                if (gameState.log.length > 100) gameState.log.pop();
+                gameState.log.push({ day: gameState.day, message, type });
             }
         }
         


### PR DESCRIPTION
## Summary
- Append new log entries instead of prepending, so latest day appears at the bottom
- Remove 100-entry cutoff to retain full history until reset

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ac44b0f083229570050ff8a4171d