### PR TITLE
Prevent concurrent goal seek/analysis runs

### DIFF
--- a/index.html
+++ b/index.html
@@ -959,6 +959,7 @@
         function setButtonsState(enabled) {
             isSimulating = !enabled;
             [aiNextDayButton, aiRunAllButton, restButton, recreateButton, aiRunMultiButton].forEach(b => b.disabled = !enabled);
+            document.querySelectorAll('.goal-seek-btn').forEach(btn => btn.disabled = !enabled);
             updateTrainingActionsUI();
         }
         


### PR DESCRIPTION
## Summary
- disable goal seek buttons during simulation to prevent concurrent "Find Best" operations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b28d75ac8322af477c62eadd8c21