### PR TITLE
Run deck analysis after deck optimization

### DIFF
--- a/index.html
+++ b/index.html
@@ -1690,7 +1690,7 @@
 
             progressContainer.classList.add('hidden');
             isSimulating = false;
-            enableAllButtons();
+            await handleMultiSim(); // Run deck analysis after optimization
         }
 
         function displayGoalSeekResults(results) {


### PR DESCRIPTION
## Summary
- Automatically trigger multi-run deck analysis after deck optimization to evaluate the optimized deck

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b20628788322b10cd9f028932281