### PR TITLE
Invalidate Find Best cache when stats or goals change

### DIFF
--- a/index.html
+++ b/index.html
@@ -650,6 +650,7 @@
                 // Any manual change sets preset to custom
                 if (e.target.tagName === 'INPUT' || e.target.tagName === 'SELECT') {
                     targetPresetSelect.value = 'custom';
+                    invalidateGoalSeekCache();
                 }
                 saveTargetsToLocalStorage();
             });
@@ -675,6 +676,7 @@
             statsContainer.addEventListener('change', (e) => {
                 if (e.target.classList.contains('character-bonus-select')) {
                     saveStatBonusesToLocalStorage();
+                    invalidateGoalSeekCache();
                     init();
                 }
             });
@@ -682,6 +684,7 @@
                 if (e.target.classList.contains('starting-stat-input')) {
                     saveStartingStatsToLocalStorage();
                     initialStartingStats = getStartingStatsFromUI(); // Update the stored initial state
+                    invalidateGoalSeekCache();
                 }
             });
         }
@@ -1789,6 +1792,7 @@
                 }
             }
             saveTargetsToLocalStorage(); // Save after applying
+            invalidateGoalSeekCache();
         }
         
         function updateGoalSeekFilterUI() {
@@ -1884,6 +1888,8 @@
         targetPresetSelect.addEventListener('change', (e) => {
             if (e.target.value !== 'custom') {
                 applyTargetPreset(e.target.value);
+            } else {
+                invalidateGoalSeekCache();
             }
         });
         settingsButton.addEventListener('click', () => {
@@ -1909,10 +1915,12 @@
             const gutsPrioritySelect = document.getElementById('priority-guts');
             if (gutsPrioritySelect) gutsPrioritySelect.disabled = e.target.checked;
             saveSettingsToLocalStorage();
+            invalidateGoalSeekCache();
         });
         targetDistanceSelect.addEventListener('change', (e) => {
             currentSettings.targetDistance = parseInt(e.target.value);
             saveSettingsToLocalStorage();
+            invalidateGoalSeekCache();
         });
 
         // --- START SIMULATION ---


### PR DESCRIPTION
## Summary
- Invalidate cached Find Best results when target stat inputs are modified or presets applied
- Refresh cache when base stats or their bonuses change
- Clear cache when dynamic guts valuation or target distance updates

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b67e6c0083228cd75b94df0bf4c4