### PR TITLE
Ensure target distance tracks stat presets

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,6 +322,13 @@
             long:   { speed: 1200, stamina: 1200, power: 1200, guts: 400, wit: 400 }
         };
 
+        const TARGET_DISTANCE_PRESETS = {
+            sprint: 1400,
+            mile: 1800,
+            medium: 2400,
+            long: 3600
+        };
+
         const TRAINING_DATA = {
             Speed:   { base_cost: 21, levels: [{ speed: 10, power: 5 }, { speed: 11, power: 5 }, { speed: 12, power: 5 }, { speed: 13, power: 6 }, { speed: 14, power: 7 }] },
             Stamina: { base_cost: 19, levels: [{ stamina: 9, guts: 4 }, { stamina: 10, guts: 4 }, { stamina: 11, guts: 4 }, { stamina: 12, guts: 5 }, { stamina: 13, guts: 6 }] },
@@ -1787,6 +1794,12 @@
                 if (input) {
                     input.value = preset[stat];
                 }
+            }
+            const distance = TARGET_DISTANCE_PRESETS[presetName];
+            if (distance) {
+                targetDistanceSelect.value = distance;
+                currentSettings.targetDistance = distance;
+                saveSettingsToLocalStorage();
             }
             saveTargetsToLocalStorage(); // Save after applying
         }


### PR DESCRIPTION
## Summary
- Map each target stat preset to a default distance
- Update preset selection to adjust target distance and settings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b7ae6d388322990717a030df9471