### PR TITLE
feat: add missing LB1 and LB3 goal seek filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -1840,7 +1840,7 @@
                 label.textContent = rarity;
                 div.appendChild(label);
 
-                [0, 2, 4].forEach(lb => {
+                [0, 1, 2, 3, 4].forEach(lb => {
                     const checkboxId = `gs-${rarity}-${lb}`;
                     const checkboxWrapper = document.createElement('div');
                     checkboxWrapper.className = 'flex items-center';


### PR DESCRIPTION
## Summary
- show LB1 and LB3 checkboxes in Goal Seek filter

## Testing
- `npm test` (fails: missing package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a2bc2f322083228940197eeb90c926