### PR TITLE
Move baseline guts valuation to settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,13 +153,9 @@
                             <input type="checkbox" id="dynamic-guts-toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
                             <label for="dynamic-guts-toggle" class="text-sm font-medium text-gray-700">Dynamic Guts Valuation</label>
                         </div>
-                        <div class="mt-3 flex items-center space-x-2">
-                            <input type="checkbox" id="guts-baseline-toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                            <label for="guts-baseline-toggle" class="text-sm font-medium text-gray-700">Clamp Guts to Baseline</label>
-                        </div>
-                        <div class="mt-3">
-                            <label for="target-distance-select" class="block text-sm font-medium text-gray-700">Target Distance</label>
-                            <select id="target-distance-select" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2 text-sm" disabled>
+                          <div class="mt-3">
+                              <label for="target-distance-select" class="block text-sm font-medium text-gray-700">Target Distance</label>
+                              <select id="target-distance-select" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2 text-sm" disabled>
                                 <option value="1400">1400m</option>
                                 <option value="1800">1800m</option>
                                 <option value="2400" selected>2400m</option>
@@ -285,15 +281,19 @@
                     <label for="mood-down-chance" class="block text-sm font-medium text-gray-700">Mood Down Chance (%)</label>
                     <input type="number" id="mood-down-chance" value="2.5" step="0.1" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2">
                 </div>
-                <div class="flex items-center space-x-2">
-                    <input type="checkbox" id="delay-for-rainbows-toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
-                    <label for="delay-for-rainbows-toggle" class="text-sm font-medium text-gray-700">Delay for Rainbows</label>
-                </div>
-                <div id="goal-seek-filter-settings">
-                    <h4 class="text-md font-medium text-gray-800 border-t pt-4">Goal Seek Filter</h4>
-                    <div class="space-y-2 mt-2">
-                        <!-- Checkboxes will be populated by JS -->
-                    </div>
+                  <div class="flex items-center space-x-2">
+                      <input type="checkbox" id="delay-for-rainbows-toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                      <label for="delay-for-rainbows-toggle" class="text-sm font-medium text-gray-700">Delay for Rainbows</label>
+                  </div>
+                  <div class="flex items-center space-x-2">
+                      <input type="checkbox" id="use-baseline-guts-toggle" class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                      <label for="use-baseline-guts-toggle" class="text-sm font-medium text-gray-700">Use Baseline Guts for Initial Guts Valuation</label>
+                  </div>
+                  <div id="goal-seek-filter-settings">
+                      <h4 class="text-md font-medium text-gray-800 border-t pt-4">Goal Seek Filter</h4>
+                      <div class="space-y-2 mt-2">
+                          <!-- Checkboxes will be populated by JS -->
+                      </div>
                 </div>
             </div>
             <div class="px-4 py-3 bg-gray-50 text-right">
@@ -362,7 +362,7 @@
         }
 
         function gutsGainToStamina(distance, currentGuts, gain) {
-            if (currentSettings.gutsBaselineClamp) {
+            if (currentSettings.useBaselineGuts) {
                 const baseline = GUTS_BASELINES[distance];
                 const effectiveGuts = Math.max(currentGuts, baseline);
                 return gutsToStamina(distance, effectiveGuts + gain) - gutsToStamina(distance, effectiveGuts);
@@ -425,7 +425,7 @@
         const delayForRainbowsToggle = document.getElementById('delay-for-rainbows-toggle');
         const goalSeekFilterSettings = document.getElementById('goal-seek-filter-settings');
         const dynamicGutsToggle = document.getElementById('dynamic-guts-toggle');
-        const gutsBaselineToggle = document.getElementById('guts-baseline-toggle');
+        const useBaselineGutsToggle = document.getElementById('use-baseline-guts-toggle');
         const targetDistanceSelect = document.getElementById('target-distance-select');
 
         // --- LOCAL STORAGE FUNCTIONS ---
@@ -537,6 +537,10 @@
 
         function loadSettingsFromLocalStorage() {
             const savedSettings = JSON.parse(localStorage.getItem(SETTINGS_STORAGE_KEY) || '{}');
+            if (savedSettings.hasOwnProperty('gutsBaselineClamp')) {
+                savedSettings.useBaselineGuts = savedSettings.gutsBaselineClamp;
+                delete savedSettings.gutsBaselineClamp;
+            }
             const defaultSettings = {
                 moodDownChance: 2.5,
                 delayForRainbows: false,
@@ -546,7 +550,7 @@
                     R: [4]
                 },
                 dynamicGutsValuation: false,
-                gutsBaselineClamp: false,
+                useBaselineGuts: true,
                 targetDistance: 2400
             };
             currentSettings = { ...defaultSettings, ...savedSettings };
@@ -555,10 +559,10 @@
             moodDownChanceInput.value = currentSettings.moodDownChance;
             delayForRainbowsToggle.checked = currentSettings.delayForRainbows;
             dynamicGutsToggle.checked = currentSettings.dynamicGutsValuation;
-            gutsBaselineToggle.checked = currentSettings.gutsBaselineClamp;
+            useBaselineGutsToggle.checked = currentSettings.useBaselineGuts;
             targetDistanceSelect.value = currentSettings.targetDistance;
             targetDistanceSelect.disabled = !currentSettings.dynamicGutsValuation;
-            gutsBaselineToggle.disabled = !currentSettings.dynamicGutsValuation;
+            useBaselineGutsToggle.disabled = !currentSettings.dynamicGutsValuation;
             const gutsPrioritySelect = document.getElementById('priority-guts');
             if (gutsPrioritySelect) gutsPrioritySelect.disabled = currentSettings.dynamicGutsValuation;
             updateGoalSeekFilterUI();
@@ -2028,12 +2032,12 @@
             targetDistanceSelect.disabled = !e.target.checked;
             const gutsPrioritySelect = document.getElementById('priority-guts');
             if (gutsPrioritySelect) gutsPrioritySelect.disabled = e.target.checked;
-            gutsBaselineToggle.disabled = !e.target.checked;
+            useBaselineGutsToggle.disabled = !e.target.checked;
             saveSettingsToLocalStorage();
             invalidateGoalSeekCache();
         });
-        gutsBaselineToggle.addEventListener('change', (e) => {
-            currentSettings.gutsBaselineClamp = e.target.checked;
+        useBaselineGutsToggle.addEventListener('change', (e) => {
+            currentSettings.useBaselineGuts = e.target.checked;
             saveSettingsToLocalStorage();
             invalidateGoalSeekCache();
         });


### PR DESCRIPTION
## Summary
- Enable baseline guts for initial valuation by default
- Move baseline guts toggle into the Settings modal and rename

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3032129fc8322a5068f6654506174