### PR TITLE
Track analysis deltas and raise default simulation count

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,7 +200,7 @@
                     <div class="space-y-3">
                         <div>
                             <label for="run-count" class="block text-sm font-medium text-gray-700">Number of Simulations</label>
-                            <input type="number" id="run-count" value="100" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2">
+                            <input type="number" id="run-count" value="2500" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2">
                         </div>
                         <button id="ai-run-multi" class="w-full bg-purple-600 hover:bg-purple-700 text-white font-bold py-3 px-4 rounded-lg transition">Run Analysis</button>
                         <div id="multi-sim-progress-container" class="hidden mt-2">
@@ -406,6 +406,18 @@
         const progressContainer = document.getElementById('multi-sim-progress-container');
         const progressBar = document.getElementById('multi-sim-progress-bar');
         const progressText = document.getElementById('multi-sim-progress-text');
+
+        let previousAnalysis = null;
+
+        function formatDelta(current, previous, decimals = 0) {
+            if (previous === undefined) return '';
+            const diff = parseFloat((current - previous).toFixed(decimals));
+            if (diff === 0) return '';
+            const sign = diff > 0 ? '+' : '';
+            const color = diff > 0 ? 'text-green-600' : 'text-red-600';
+            return ` <span class="${color} text-xs">(${sign}${diff})</span>`;
+        }
+
         const modal = document.getElementById('card-select-modal');
         const modalCloseButton = document.getElementById('modal-close-button');
         const cardTypeFilter = document.getElementById('card-type-filter');
@@ -1564,7 +1576,7 @@
             isSimulating = true;
             resultsContainer.classList.add('hidden');
             progressContainer.classList.remove('hidden');
-            const numRuns = parseInt(runCountInput.value) || 100;
+            const numRuns = parseInt(runCountInput.value) || 2500;
             const targetStats = getTargetStatsFromUI();
             const bondWeights = getBondWeightsFromUI();
             const allResults = [];
@@ -1617,37 +1629,39 @@
                 if (stat === 'effectiveStamina') {
                     return `<tr>
                         <td class="px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-900">${statLabel}</td>
-                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].min}</td>
-                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].mean}</td>
-                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].std}</td>
-                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].max}</td>
+                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].min}${formatDelta(analysis[stat].min, previousAnalysis?.[stat]?.min)}</td>
+                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].mean}${formatDelta(analysis[stat].mean, previousAnalysis?.[stat]?.mean)}</td>
+                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].std}${formatDelta(analysis[stat].std, previousAnalysis?.[stat]?.std)}</td>
+                        <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].max}${formatDelta(analysis[stat].max, previousAnalysis?.[stat]?.max)}</td>
                         <td class="px-4 py-2"></td>
                     </tr>`;
                 }
                 const metTargetRuns = results.filter(r => r.metTargets[stat]).length;
                 const metTargetPercentage = (metTargetRuns / results.length) * 100;
+                analysis[stat].targetPercentage = parseFloat(metTargetPercentage.toFixed(2));
                 return `<tr>
                     <td class="px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-900 capitalize">${statLabel}</td>
-                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].min}</td>
-                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].mean}</td>
-                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].std}</td>
-                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].max}</td>
-                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-800 font-bold">${metTargetPercentage.toFixed(2)}%</td>
+                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].min}${formatDelta(analysis[stat].min, previousAnalysis?.[stat]?.min)}</td>
+                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].mean}${formatDelta(analysis[stat].mean, previousAnalysis?.[stat]?.mean)}</td>
+                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].std}${formatDelta(analysis[stat].std, previousAnalysis?.[stat]?.std)}</td>
+                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${analysis[stat].max}${formatDelta(analysis[stat].max, previousAnalysis?.[stat]?.max)}</td>
+                    <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-800 font-bold">${metTargetPercentage.toFixed(2)}%${formatDelta(metTargetPercentage, previousAnalysis?.[stat]?.targetPercentage, 2)}</td>
                 </tr>`;
             }).join('');
 
             const totalStat = analysis['total'];
             tableHTML += `<tr class="bg-gray-50">
                 <td class="px-4 py-2 whitespace-nowrap text-sm font-bold text-gray-900">Total</td>
-                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.min}</td>
-                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.mean}</td>
-                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.std}</td>
-                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.max}</td>
+                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.min}${formatDelta(totalStat.min, previousAnalysis?.total?.min)}</td>
+                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.mean}${formatDelta(totalStat.mean, previousAnalysis?.total?.mean)}</td>
+                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.std}${formatDelta(totalStat.std, previousAnalysis?.total?.std)}</td>
+                <td class="px-4 py-2 whitespace-nowrap text-sm text-gray-500">${totalStat.max}${formatDelta(totalStat.max, previousAnalysis?.total?.max)}</td>
                 <td class="px-4 py-2"></td>
             </tr>`;
 
             resultsBody.innerHTML = tableHTML;
             resultsContainer.classList.remove('hidden');
+            previousAnalysis = JSON.parse(JSON.stringify(analysis));
         }
 
         // --- Goal Seek Functions ---


### PR DESCRIPTION
## Summary
- Default multi-run analysis now starts with 2500 simulations
- Analysis table shows +/- deltas compared to previous run

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3037319a48322912f810d013f0527