### PR TITLE
Add detailed action analysis and friendship tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -1401,7 +1401,7 @@
             if (gs.bondsMaxed) {
                 gs.friendCountsThisTurn = {};
                 TRAINING_TYPES.forEach(type => {
-                    gs.friendCountsThisTurn[type] = gs.supportCards.filter(c => c && c.type !== 6 && c.location === type && c.friendship >= FRIENDSHIP_BOND_THRESHOLD).length;
+                    gs.friendCountsThisTurn[type] = gs.supportCards.filter(c => c && c.type !== 6 && c.location === type && c.friendship >= FRIENDSHIP_BOND_THRESHOLD && type === TYPE_MAP[c.type]).length;
                 });
             }
 


### PR DESCRIPTION
## Summary
- allow filtering analysis to turns after a chosen start turn
- track counts and average gains for each action across simulations
- report average friendship trainings per turn once bonds are maxed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a632b6826c83229bf21a68be8d25f2