### PR TITLE
Add bonus analysis to stats UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
                     <div id="stats-container" class="grid grid-cols-2 gap-3">
                         <!-- Stats will be populated by JS -->
                     </div>
+                    <button id="find-best-bonus-btn" class="mt-3 w-full p-2 border-2 border-dashed rounded-lg text-purple-400 hover:bg-purple-50 hover:border-purple-400">Find Best Bonus</button>
                 </div>
                 <div class="bg-white p-4 rounded-xl shadow-md">
                     <div id="toggle-support-cards" class="flex justify-between items-center cursor-pointer border-b pb-2 mb-3">
@@ -271,6 +272,20 @@
             </div>
         </div>
     </div>
+
+    <!-- Bonus Analysis Modal -->
+    <div id="bonus-analysis-modal" class="fixed inset-0 z-50 items-center justify-center hidden">
+        <div class="modal-bg absolute inset-0"></div>
+        <div class="relative bg-white rounded-lg shadow-xl max-w-lg w-full m-4">
+            <div class="p-4 border-b">
+                <h3 class="text-lg font-medium leading-6 text-gray-900">Bonus Analysis Results</h3>
+            </div>
+            <div id="bonus-analysis-list" class="p-4 max-h-80 overflow-y-auto"></div>
+            <div class="px-4 py-3 bg-gray-50 text-right">
+                <button id="bonus-analysis-close-button" type="button" class="inline-flex justify-center rounded-md border border-transparent bg-red-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-red-700">Close</button>
+            </div>
+        </div>
+    </div>
     
     <!-- Settings Modal -->
     <div id="settings-modal" class="fixed inset-0 z-50 items-center justify-center hidden">
@@ -397,6 +412,10 @@
         const deckOptimizeButton = document.getElementById('deck-optimize-btn');
         const targetStatsInputsContainer = document.getElementById('target-stats-inputs');
         const statsContainer = document.getElementById('stats-container');
+        const findBestBonusBtn = document.getElementById('find-best-bonus-btn');
+        const bonusAnalysisModal = document.getElementById('bonus-analysis-modal');
+        const bonusAnalysisList = document.getElementById('bonus-analysis-list');
+        const bonusAnalysisCloseButton = document.getElementById('bonus-analysis-close-button');
         const aiNextDayButton = document.getElementById('ai-next-day');
         const aiRunAllButton = document.getElementById('ai-run-all');
         const resetSimButton = document.getElementById('reset-sim');
@@ -587,7 +606,7 @@
 
 
         // --- INITIALIZATION ---
-        function init(isSilent = false) {
+        function init(isSilent = false, bonusOverrides = null) {
             isSimulating = false;
             previousStats = null;
             
@@ -606,7 +625,7 @@
                 training: { Speed: { level: 1, uses: 0 }, Stamina: { level: 1, uses: 0 }, Power: { level: 1, uses: 0 }, Guts: { level: 1, uses: 0 }, Wit: { level: 1, uses: 0 } },
                 supportCards: [], primaryStat: 'Speed', log: [],
                 reporter: { bond: 0, location: null },
-                characterBonuses: getStatBonusesFromUI(),
+                characterBonuses: bonusOverrides || getStatBonusesFromUI(),
                 initialStatsApplied: false,
                 isSilent: isSilent
             };
@@ -1007,7 +1026,7 @@
 
         function setButtonsState(enabled) {
             isSimulating = !enabled;
-            [aiNextDayButton, aiRunAllButton, restButton, recreateButton, aiRunMultiButton].forEach(b => b.disabled = !enabled);
+            [aiNextDayButton, aiRunAllButton, restButton, recreateButton, aiRunMultiButton, findBestBonusBtn].forEach(b => b.disabled = !enabled);
             document.querySelectorAll('.goal-seek-btn').forEach(btn => btn.disabled = !enabled);
             updateTrainingActionsUI();
         }
@@ -1586,8 +1605,8 @@
             simulationStep();
         }
 
-        function runSilentSimulation(targetStats, bondWeights, delayForRainbows) {
-            const localGS = init(true);
+        function runSilentSimulation(targetStats, bondWeights, delayForRainbows, bonusOverrides = null) {
+            const localGS = init(true, bonusOverrides);
             localGS.turnLog = [];
             applyInitialCardStats(localGS);
             placeSupportCards(localGS);
@@ -1817,7 +1836,7 @@
             init(); // Re-initialize to reflect the cleared slot
         }
 
-        async function runGoalSeekAnalysis(numRuns) {
+        async function runGoalSeekAnalysis(numRuns, bonusOverrides = null) {
             const targetStats = getTargetStatsFromUI();
             const bondWeights = getBondWeightsFromUI();
             let totalWeightedSum = 0;
@@ -1829,7 +1848,7 @@
                 : 0;
             const targetEffectiveStamina = targetStats.values.stamina;
             for (let i = 0; i < numRuns; i++) {
-                const result = runSilentSimulation(targetStats, bondWeights, currentSettings.delayForRainbows);
+                const result = runSilentSimulation(targetStats, bondWeights, currentSettings.delayForRainbows, bonusOverrides);
                 const currentGutsOffset = currentSettings.dynamicGutsValuation
                     ? gutsToStamina(distance, Math.max(result.guts, baselineGuts))
                     : 0;
@@ -1956,6 +1975,65 @@
             goalSeekList.innerHTML = tableHTML;
             goalSeekModal.classList.remove('hidden');
             goalSeekModal.classList.add('flex');
+        }
+
+        // --- Bonus Analysis Functions ---
+        function generateBonusCombinations() {
+            const values = [0, 0.1, 0.2];
+            const combos = [];
+            function helper(index, current, sum) {
+                if (index === STAT_MAP.length) {
+                    if (Math.abs(sum - 0.3) < 1e-9) {
+                        combos.push({ ...current });
+                    }
+                    return;
+                }
+                const stat = STAT_MAP[index];
+                for (const val of values) {
+                    current[stat] = val;
+                    helper(index + 1, current, sum + val);
+                }
+            }
+            helper(0, {}, 0);
+            return combos;
+        }
+
+        function displayBonusAnalysisResults(results) {
+            let tableHTML = `<table class="min-w-full divide-y divide-gray-200">` +
+                `<thead class=\"bg-gray-50\"><tr>` +
+                `<th class=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">Rank</th>` +
+                `<th class=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">Bonuses</th>` +
+                `<th class=\"px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider\">Mean Weighted Total</th>` +
+                `</tr></thead><tbody class=\"bg-white divide-y divide-gray-200\">`;
+            results.forEach((res, index) => {
+                const bonusString = STAT_MAP
+                    .map(stat => `${stat.charAt(0).toUpperCase() + stat.slice(1)} ${res.combo[stat] * 100}%`)
+                    .join(', ');
+                tableHTML += `<tr><td class=\"px-4 py-2 whitespace-nowrap text-sm font-medium text-gray-900\">${index + 1}</td>` +
+                    `<td class=\"px-4 py-2 whitespace-nowrap text-sm text-gray-500\">${bonusString}</td>` +
+                    `<td class=\"px-4 py-2 whitespace-nowrap text-sm font-bold text-blue-600\">${Math.floor(res.meanWeightedTotal)}</td></tr>`;
+            });
+            tableHTML += `</tbody></table>`;
+            bonusAnalysisList.innerHTML = tableHTML;
+            bonusAnalysisModal.classList.remove('hidden');
+            bonusAnalysisModal.classList.add('flex');
+        }
+
+        async function handleBestBonus() {
+            if (isSimulating) return;
+            disableAllButtons();
+            isSimulating = true;
+            const combos = generateBonusCombinations();
+            const results = [];
+            for (const combo of combos) {
+                const meanWeightedTotal = await runGoalSeekAnalysis(100, combo);
+                results.push({ combo, meanWeightedTotal });
+                await new Promise(r => setTimeout(r, 0));
+            }
+            results.sort((a, b) => b.meanWeightedTotal - a.meanWeightedTotal);
+            displayBonusAnalysisResults(results);
+            isSimulating = false;
+            enableAllButtons();
         }
 
 
@@ -2124,6 +2202,11 @@
                 goalSeekModal.classList.remove('flex');
                 init();
             }
+        });
+        findBestBonusBtn.addEventListener('click', handleBestBonus);
+        bonusAnalysisCloseButton.addEventListener('click', () => {
+            bonusAnalysisModal.classList.add('hidden');
+            bonusAnalysisModal.classList.remove('flex');
         });
         targetPresetSelect.addEventListener('change', (e) => {
             if (e.target.value !== 'custom') {


### PR DESCRIPTION
## Summary
- add Find Best Bonus button to stats card
- analyze bonus distributions totaling 30% and show results in modal
- allow simulation functions to use temporary bonus overrides

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a65ca11ed08322a772eec7ab7ab255