### PR TITLE
Handle gaps when showing support card tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -839,8 +839,9 @@
                 const slot = e.target.closest('.card-slot-rendered');
                 if (slot) {
                     const index = parseInt(slot.closest('[data-index]').dataset.index);
-                    const card = getDeckFromUI()[index];
-                    if (card) {
+                    const cardInfo = selectedCards[index];
+                    if (cardInfo) {
+                        const card = ALL_CARDS_DATA.find(c => c.id === cardInfo.id && c.limit_break === cardInfo.limit_break) || cardInfo;
                         showTooltip(e, card);
                     }
                 }


### PR DESCRIPTION
## Summary
- Ensure tooltip uses the correct card even when there are empty slots

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8eaeae9388322af87d9b8a56e0393