### PR TITLE
Add Guts/Stamina calculator modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -332,7 +332,13 @@
             <div class="p-4 space-y-4">
                 <div>
                     <label for="guts-calc-distance" class="block text-sm font-medium text-gray-700">Distance</label>
-                    <input type="number" id="guts-calc-distance" value="2400" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2">
+                    <select id="guts-calc-distance" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm p-2">
+                        <option value="1400">1400</option>
+                        <option value="1800">1800</option>
+                        <option value="2400" selected>2400</option>
+                        <option value="3000">3000</option>
+                        <option value="3600">3600</option>
+                    </select>
                 </div>
                 <div>
                     <label for="guts-calc-guts" class="block text-sm font-medium text-gray-700">Guts</label>


### PR DESCRIPTION
## Summary
- Add header button to open new Guts/Stamina/Distance calculator
- Implement modal to compute equivalent stamina at baseline Guts target
- Wire up JavaScript handlers to display modal and calculate equivalent stamina

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68b2028296048322b2a18b4358a2250d