### PR TITLE
Add 5% stat bonus increments

### DIFF
--- a/index.html
+++ b/index.html
@@ -764,7 +764,9 @@
                         <label class="text-xs font-medium text-gray-500">Bonus
                             <select id="bonus-${stat}" class="character-bonus-select text-xs rounded border-gray-300 bg-white shadow-sm" data-stat="${stat}">
                                 <option value="0">0%</option>
+                                <option value="0.05">+5%</option>
                                 <option value="0.1">+10%</option>
+                                <option value="0.15">+15%</option>
                                 <option value="0.2">+20%</option>
                             </select>
                         </label>


### PR DESCRIPTION
## Summary
- add 5% and 15% stat bonus options to the stat bonus selector so users can adjust bonuses in 5% steps

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e07f15581c8322a696ab09cffb753a